### PR TITLE
Update curl command line in README installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install
 
 `github_upload` is most easily installed as a standalone script:
 
-    $ curl -s http://github.com/github/upload/raw/master/upload.rb > ~/bin/github_upload
+    $ curl -sLk http://github.com/github/upload/raw/master/upload.rb > ~/bin/github_upload
     $ chmod 755 ~/bin/github_upload
     $ gem install xml-simple mime-types
 


### PR DESCRIPTION
The change adds the -L switch, which asks curl to follow redirects (needed to follow the redirect to HTTPS), and the -k switch to ignore certificate errors. I'm not sure if the latter is a good idea, but it's necessary when using curl on CygWin. Note that not including the -k switch may cause curl to fail the download silently, with no indication of what the problem is, due to the -s switch.
